### PR TITLE
Change content of CODEOWNERS to be compliant

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@dfinity/gix
+* @dfinity/gix


### PR DESCRIPTION
The format needs to pass a compliance check of
https://github.com/dfinity/repositories-open-to-contributions which is why it needs to be adjusted here.