### PR TITLE
Change API to enforce usage of domain separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ To prepare a signature on a message, add it's `hash` to the signature map togeth
 ```rust
 use canister_sig_util::hash_bytes;
 
+/// The signature domain should be unique for the context in which the signature is used.
+const SIG_DOMAIN: &[u8] = b"ic-example-canister-sig";
+
 fn add_signature(seed: &[u8], message: &[u8]) {
     SIGNATURES.with(|sigs| {
         let mut sigs = sigs.borrow_mut();
-        // The hash should always use a domain separator in order to make sure that the signature cannot be
-        // used outside the intended context.
-        let msg_hash = hash_with_domain(b"ic-example-canister-sig", message);
-        sigs.add_signature(seed, msg_hash);
+        sigs.add_signature(seed, &SIG_DOMAIN, message);
     });
 }
 ```

--- a/README.md
+++ b/README.md
@@ -38,9 +38,13 @@ use canister_sig_util::hash_bytes;
 const SIG_DOMAIN: &[u8] = b"ic-example-canister-sig";
 
 fn add_signature(seed: &[u8], message: &[u8]) {
-    SIGNATURES.with(|sigs| {
-        let mut sigs = sigs.borrow_mut();
-        sigs.add_signature(seed, &SIG_DOMAIN, message);
+    let sig_inputs = CanisterSigInputs {
+        domain: SIG_DOMAIN,
+        seed,
+        message,
+    };
+    SIGNATURES.with_borrow_mut(|sigs| {
+        sigs.add_signature(&sig_inputs);
     });
 }
 ```
@@ -62,10 +66,18 @@ fn update_root_hash() {
 To retrieve a prepared signature, use the `get_signature_as_cbor` on the `SignatureMap` instance:
 
 ```rust
-fn get_signature(seed: &[u8], message_hash: Hash) -> Result<Vec<u8>, String> {
-    SIGNATURES.with(|sigs| {
-        let sig_map = sigs.borrow();
-        sig_map.get_signature_as_cbor(seed, message_hash, None)
+
+/// The signature domain should be unique for the context in which the signature is used.
+const SIG_DOMAIN: &[u8] = b"ic-example-canister-sig";
+
+fn get_signature(seed: &[u8], message: &[u8]) -> Result<Vec<u8>, String> {
+    let sig_inputs = CanisterSigInputs {
+        domain: SIG_DOMAIN,
+        seed,
+        message,
+    };
+    SIGNATURES.with_borrow(|sigs| {
+        sigs.get_signature_as_cbor(&sig_inputs, None)
     });
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,13 +172,6 @@ pub fn delegation_signature_msg(
     representation_independent_hash(m.as_slice()).to_vec()
 }
 
-fn msg_with_domain(sep: &[u8], bytes: &[u8]) -> Vec<u8> {
-    let mut msg = vec![sep.len() as u8];
-    msg.append(&mut sep.to_vec());
-    msg.append(&mut bytes.to_vec());
-    msg
-}
-
 #[derive(Serialize)]
 struct CanisterSig {
     certificate: ByteBuf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,10 @@ pub const CANISTER_SIG_PK_DER_PREFIX_LENGTH: usize = 19;
 pub const CANISTER_SIG_PK_DER_OID: &[u8; 14] =
     b"\x30\x0C\x06\x0A\x2B\x06\x01\x04\x01\x83\xB8\x43\x01\x02";
 
+/// Signature domain for IC request auth delegations as specified in the IC interface specification:
+/// https://internetcomputer.org/docs/current/references/ic-interface-spec/#authentication
+pub const DELEGATION_SIG_DOMAIN: &[u8] = b"ic-request-auth-delegation";
+
 lazy_static! {
     /// The IC root public key used when verifying canister signatures.
     pub static ref IC_ROOT_PUBLIC_KEY: Vec<u8> =
@@ -145,6 +149,11 @@ pub fn hash_with_domain(sep: &[u8], bytes: &[u8]) -> Hash {
     hasher.finalize().into()
 }
 
+/// Computes the signing input for a signature on an IC request authentication delegation.
+/// It can be used in conjunction with the [DELEGATION_SIG_DOMAIN] to create
+/// a signed `sender_delegation`.
+/// Relevant part of the IC interface specification:
+/// https://internetcomputer.org/docs/current/references/ic-interface-spec#authentication
 pub fn delegation_signature_msg(
     pubkey: &[u8],
     expiration: u64,
@@ -160,8 +169,7 @@ pub fn delegation_signature_msg(
         }
         m.push(("targets".into(), Value::Array(arr)));
     }
-    let map_hash = representation_independent_hash(m.as_slice());
-    msg_with_domain(b"ic-request-auth-delegation", &map_hash)
+    representation_independent_hash(m.as_slice()).to_vec()
 }
 
 fn msg_with_domain(sep: &[u8], bytes: &[u8]) -> Vec<u8> {

--- a/src/signature_map.rs
+++ b/src/signature_map.rs
@@ -40,9 +40,9 @@ struct SigExpiration {
 /// - message: The message to sign.
 #[derive(PartialEq, Eq)]
 pub struct CanisterSigInputs<'a> {
-    pub domain: &'a[u8],
-    pub seed: &'a[u8],
-    pub message: &'a[u8],
+    pub domain: &'a [u8],
+    pub seed: &'a [u8],
+    pub message: &'a [u8],
 }
 
 impl CanisterSigInputs<'_> {


### PR DESCRIPTION
This changes the API of the signature map to enforce usage of a domain separator.

Note:
* Includes a few drive-by documentation improvements
* The test suite is inadequate at the moment. Tests will be added in a separate PR.