### PR TITLE
Introduce proper errors for get_signature_as_cbor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_cbor = "0.11"
 sha2 = "0.10"
+thiserror = "1"
 
 [dev-dependencies]
 assert_matches = "1.5"


### PR DESCRIPTION
Knowing there are exactly two error cases is much nicer than just a generic `String` type.