### PR TITLE
Expand testsuite to cover the public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use candid::Principal;
 use ic_certification::{Hash, HashTree};
 use ic_representation_independent_hash::{representation_independent_hash, Value};
 use lazy_static::lazy_static;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 use sha2::{Digest, Sha256};
 
@@ -172,7 +172,7 @@ pub fn delegation_signature_msg(
     representation_independent_hash(m.as_slice()).to_vec()
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 struct CanisterSig {
     certificate: ByteBuf,
     tree: HashTree,

--- a/src/signature_map.rs
+++ b/src/signature_map.rs
@@ -152,6 +152,19 @@ impl SignatureMap {
         maybe_certified_assets_root_hash: Option<Hash>,
     ) -> Result<Vec<u8>, CanisterSigError> {
         let certificate = data_certificate().ok_or(CanisterSigError::NoCertificate)?;
+        self.get_signature_as_cbor_internal(
+            sig_inputs,
+            certificate,
+            maybe_certified_assets_root_hash,
+        )
+    }
+
+    fn get_signature_as_cbor_internal(
+        &self,
+        sig_inputs: &CanisterSigInputs,
+        certificate: Vec<u8>,
+        maybe_certified_assets_root_hash: Option<Hash>,
+    ) -> Result<Vec<u8>, CanisterSigError> {
         let witness = self
             .witness(sig_inputs.seed, sig_inputs.message_hash())
             .ok_or(CanisterSigError::NoSignature)?;
@@ -184,7 +197,10 @@ impl SignatureMap {
     /// Adds a signature to the map, given the signature inputs.
     pub fn add_signature(&mut self, sig_inputs: &CanisterSigInputs) {
         let now = time();
+        self.add_signature_internal(sig_inputs, now);
+    }
 
+    fn add_signature_internal(&mut self, sig_inputs: &CanisterSigInputs, now: u64) {
         self.prune_expired(now);
         let expires_at = now.saturating_add(SIGNATURE_EXPIRATION_PERIOD_NS);
         self.put(sig_inputs.seed, sig_inputs.message_hash(), expires_at);

--- a/src/signature_map/test.rs
+++ b/src/signature_map/test.rs
@@ -1,4 +1,6 @@
 use super::*;
+use assert_matches::assert_matches;
+use ic_certification::hash_tree::SubtreeLookupResult::Found;
 use ic_certification::Hash;
 use sha2::{Digest, Sha256};
 
@@ -106,4 +108,66 @@ fn test_random_modifications() {
             }
         }
     }
+}
+
+#[test]
+fn test_signatures_pruned_on_add() {
+    const TIME_NOW: u64 = 100;
+    let mut map = SignatureMap::default();
+
+    let sig_inputs = CanisterSigInputs {
+        domain: b"ic-request-auth-delegation",
+        seed: &[1, 2, 3],
+        message: &[4, 5, 6],
+    };
+
+    for i in 0..50 {
+        map.add_signature_internal(&sig_inputs, TIME_NOW + i);
+    }
+
+    assert_eq!(map.len(), 50);
+
+    // Pruning timeout is one minute
+    map.add_signature_internal(&sig_inputs, TIME_NOW + 2 * MINUTE_NS);
+    assert_eq!(map.len(), 1);
+}
+
+#[test]
+fn test_signature_round_trip() {
+    const TIME_NOW: u64 = 100;
+    let certificate = vec![1u8, 2, 3];
+    let sig_inputs = CanisterSigInputs {
+        domain: b"ic-request-auth-delegation",
+        seed: &[1, 2, 3],
+        message: &[4, 5, 6],
+    };
+
+    let mut map = SignatureMap::default();
+    map.add_signature_internal(&sig_inputs, TIME_NOW);
+    let result = map
+        .get_signature_as_cbor_internal(&sig_inputs, certificate.clone(), None)
+        .expect("failed to get signature");
+
+    let sig: CanisterSig =
+        serde_cbor::from_slice(&result).expect("failed to deserialize signature");
+    assert_eq!(sig.certificate.as_slice(), certificate.as_slice());
+    let Found(subtree) = sig.tree.lookup_subtree([b"sig"]) else {
+        panic!("expected to find a subtree");
+    };
+    assert_eq!(subtree.digest(), map.root_hash());
+}
+
+#[test]
+fn test_signature_error_non_existing() {
+    let map = SignatureMap::default();
+
+    let sig_inputs = CanisterSigInputs {
+        domain: b"ic-request-auth-delegation",
+        seed: &[1, 2, 3],
+        message: &[4, 5, 6],
+    };
+
+    let certificate = vec![1u8, 2, 3];
+    let result = map.get_signature_as_cbor_internal(&sig_inputs, certificate, None);
+    assert_matches!(result, Err(CanisterSigError::NoSignature));
 }

--- a/src/signature_map/test.rs
+++ b/src/signature_map/test.rs
@@ -156,7 +156,11 @@ fn test_signature_round_trip() {
     };
     assert_eq!(subtree.digest(), map.root_hash());
     // canister sig path as per spec: /sig/<seed_hash>/<message_hash>
-    let path: &[&[u8]] = &[b"sig", &hash_bytes(sig_inputs.seed), &sig_inputs.message_hash()];
+    let path: &[&[u8]] = &[
+        b"sig",
+        &hash_bytes(sig_inputs.seed),
+        &sig_inputs.message_hash(),
+    ];
     assert_matches!(sig.tree.lookup_path(path), LookupResult::Found(_));
 }
 

--- a/src/signature_map/test.rs
+++ b/src/signature_map/test.rs
@@ -1,7 +1,7 @@
 use super::*;
 use assert_matches::assert_matches;
 use ic_certification::hash_tree::SubtreeLookupResult::Found;
-use ic_certification::Hash;
+use ic_certification::{Hash, LookupResult};
 use sha2::{Digest, Sha256};
 
 fn hash_bytes(value: impl AsRef<[u8]>) -> Hash {
@@ -155,6 +155,9 @@ fn test_signature_round_trip() {
         panic!("expected to find a subtree");
     };
     assert_eq!(subtree.digest(), map.root_hash());
+    // canister sig path as per spec: /sig/<seed_hash>/<message_hash>
+    let path: &[&[u8]] = &[b"sig", &hash_bytes(sig_inputs.seed), &sig_inputs.message_hash()];
+    assert_matches!(sig.tree.lookup_path(path), LookupResult::Found(_));
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a few tests to ensure that the public API of the `SignatureMap` works as intended.
Previously the tests tested only the internals of the map.