### PR TITLE
Update ic-cdk to v15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 [dependencies]
 # ic dependencies
 candid = "0.10"
-ic-cdk = "0.14"
+ic-cdk = "0.15"
 ic-certification = "2.5"
 ic-representation-independent-hash = "2.5"
 


### PR DESCRIPTION
# Motivation
ic-cdk version 14 has been yanked.

# Changes
Update `ic-cdk` to version 15.

# Tests
See CI.