### PR TITLE
chore: bump ic-certification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 # ic dependencies
 candid = "0.10"
 ic-cdk = "0.15"
-ic-certification = "2.5"
+ic-certification = "3"
 ic-representation-independent-hash = "2.5"
 
 # other dependencies
@@ -31,4 +31,4 @@ thiserror = "1"
 
 [dev-dependencies]
 assert_matches = "1.5"
-rand = { version ="0.8" }
+rand = { version = "0.8" }


### PR DESCRIPTION
The latest ic-certification version is 3. This repo currently uses version 2. For compatibility with libraries that have already updated to version 3, we bump the version.

## CI Failure

CI fails I think because this is from a fork rather than a branch from the DFINITY repo. I've asked IT to give me write permissions so I can create a branch on the DFINITY repo and then recreate this PR there. However, if you take external contributions, you may want to investigate why PRs from forks can't pass CI. Alternatively, someone could force-merge this PR