### PR TITLE
chore(rust): Update Rust to stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [pull_request]
 
 env:
-  RUST_VERSION: 1.77.2
+  RUST_VERSION: 1.83.0
 
 jobs:
   test:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.77.2" # NOTE: remember to update CI as well.
+channel = "1.83.0" # NOTE: remember to update CI as well.
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
# Motivation
The version of rust used is by now old and is holding back library updates.

# Changes
- Update Rust version to the latest stable version.